### PR TITLE
Add /ops link to DoCSoc Operations FB group

### DIFF
--- a/contents/ops/index.json
+++ b/contents/ops/index.json
@@ -1,0 +1,3 @@
+{
+    "template": "ops.jade"
+}

--- a/templates/ops.jade
+++ b/templates/ops.jade
@@ -1,0 +1,8 @@
+doctype html
+
+html(lang='en')
+  head
+    title DoCSoc Operations
+    meta(http-equiv='refresh', content='2; url=https://www.facebook.com/groups/1509850436007222/')
+    script(type='text/javascript').
+       window.location.href = "https://www.facebook.com/groups/1509850436007222/"


### PR DESCRIPTION

```
The following changes since commit 1f0f92042a58be0049b4c49792255af88571cdfd:

  Remove deprecated Facebook events widget (2016-10-09 11:13:04 +0100)

are available in the git repository at:

  https://github.com/levex/docsoc-website ops-link

for you to fetch changes up to 9ded19d9a70c52aaca88c799dcd9002aa6fa087e:

  Add /ops link to DoCSoc Operations FB group (2016-10-17 03:10:01 +0100)

----------------------------------------------------------------
Levente Kurusa (1):
      Add /ops link to DoCSoc Operations FB group

 contents/ops/index.json | 3 +++
 templates/ops.jade      | 8 ++++++++
 2 files changed, 11 insertions(+)
 create mode 100644 contents/ops/index.json
 create mode 100644 templates/ops.jade

```